### PR TITLE
Change constructor of AdvancedFilter to accept two separate condition s to enforce limit of two with second optional.

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -244,12 +244,14 @@ export class AdvancedFilter extends Filter {
   static schemaUrl: string = "http://powerbi.com/product/schema#advanced";
   
   logicalOperator: AdvancedFilterLogicalOperators;
-  conditions: IAdvancedFilterCondition[];
+  conditionA: IAdvancedFilterCondition;
+  conditionB: IAdvancedFilterCondition;
   
   constructor(
     target: IFilterTarget,
     logicalOperator: AdvancedFilterLogicalOperators,
-    ...conditions: IAdvancedFilterCondition[]
+    conditionA: IAdvancedFilterCondition,
+    conditionB?: IAdvancedFilterCondition
   ) {
     super(target);
     this.schemaUrl = AdvancedFilter.schemaUrl;
@@ -261,32 +263,19 @@ export class AdvancedFilter extends Filter {
     }
     
     this.logicalOperator = logicalOperator;
-    
-    if(conditions.length === 0) {
-      throw new Error(`conditions must be a non-empty array. You passed: ${conditions}`);
-    }
-    if(conditions.length > 2) {
-      throw new Error(`AdvancedFilters may not have more than two conditions. You passed: ${conditions.length}`);
-    }
-    
-    /**
-     * Accept conditions as array instead of as individual arguments
-     * new AdvancedFilter('a', 'b', "And", { value: 1, operator: "Equals" }, { value: 2, operator: "IsGreaterThan" });
-     * new AdvancedFilter('a', 'b', "And", [{ value: 1, operator: "Equals" }, { value: 2, operator: "IsGreaterThan" }]);
-     */
-    if(Array.isArray(conditions[0])) {
-      this.conditions = <any>conditions[0];
-    }
-    else {
-      this.conditions = conditions;
-    }
+    this.conditionA = conditionA;
+    this.conditionB = conditionB;
   }
   
   toJSON(): IAdvancedFilter {
     const filter = <IAdvancedFilter>super.toJSON();
     
     filter.logicalOperator = this.logicalOperator;
-    filter.conditions = this.conditions;
+    filter.conditions = [this.conditionA];
+    
+    if (this.conditionB) {
+      filter.conditions.push(this.conditionB);
+    }
     
     return filter;
   }

--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -285,33 +285,6 @@ describe("Unit | Filters", function () {
       expect(attemptToCreateFilter).toThrowError();
     });
     
-    it("should throw an error if more than two conditions are provided", function () {
-      // Arrange
-      const conditions: models.IAdvancedFilterCondition[] = [
-        {
-          value: "a",
-          operator: "LessThan"
-        },
-        {
-          value: "b",
-          operator: "LessThan"
-        },
-        {
-          value: "c",
-          operator: "LessThan"
-        }
-      ];
-      
-      
-      // Act
-      const attemptToCreateFilter = () => {
-        return new models.AdvancedFilter({ table: "Table", column: "c" }, "And", ...conditions);
-      };
-      
-      // Assert
-      expect(attemptToCreateFilter).toThrowError();
-    });
-    
     it("should output the correct json when toJSON is called", function () {
       // Arrange
       const expectedFilter: models.IAdvancedFilter = {
@@ -337,7 +310,8 @@ describe("Unit | Filters", function () {
       const filter = new models.AdvancedFilter(
         expectedFilter.target,
         expectedFilter.logicalOperator,
-        ...expectedFilter.conditions);
+        expectedFilter.conditions[0],
+        expectedFilter.conditions[1]);
       
       // Assert
       expect(filter.toJSON()).toEqual(expectedFilter);
@@ -384,7 +358,8 @@ describe("Unit | Filters", function () {
       const filter = new models.AdvancedFilter(
         expectedFilter.target,
         expectedFilter.logicalOperator,
-        ...expectedFilter.conditions);
+        expectedFilter.conditions[0],
+        expectedFilter.conditions[1]);
       
       // Assert
       expect(models.validateFilter(filter.toJSON())).toBeUndefined();


### PR DESCRIPTION
This makes it clear advanced filters only accept 2 conditions but this brings up other questions:

Should we change the JSON format of the filter so that the conditions is no longer an array?  This might make it easier to translate into Semantic Query internally.

If only one condition is provided at construction time, we currently only add one condition to the JSON array, however, given that there is a None operator, do we add a fake condition as placeholder for the second?

