### PR TITLE
Replace isBasicFilter and isAdvancedFilter helper functions with getFilterType and FilterType enum for scalability and better semantics.

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -159,12 +159,29 @@ export interface IAdvancedFilter extends IFilter {
   conditions: IAdvancedFilterCondition[];
 }
 
-export function isAdvancedFilter(filter: IFilter): boolean {
-  return (filter.$schema === AdvancedFilter.schemaUrl);
+export enum FilterType {
+  Advanced,
+  Basic,
+  Unknown
 }
 
-export function isBasicFilter(filter: IFilter): boolean {
-  return (filter.$schema === BasicFilter.schemaUrl);
+export function getFilterType(filter: IFilter): FilterType {
+  const basicFilter = filter as IBasicFilter;
+  const advancedFilter = filter as IAdvancedFilter;
+
+  if ((typeof basicFilter.operator === "string")
+    && (Array.isArray(basicFilter.values))
+  ) {
+    return FilterType.Basic;
+  }
+  else if ((typeof advancedFilter.logicalOperator === "string")
+    && (Array.isArray(advancedFilter.conditions))
+  ) {
+    return FilterType.Advanced;
+  }
+  else {
+    return FilterType.Unknown;
+  }
 }
 
 export function isMeasure(arg: any): arg is IFilterMeasureTarget {

--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -449,24 +449,11 @@ describe("Unit | Filters", function () {
   });
 
   describe('determine filter type', function () {
-    it('isBasicFilter should return true for objects with matching shemaUrl and false otherwise', function () {
+    it('getFilterType should return type of filter given a filter object', function () {
       // Arrange
       const testData = {
-      	filter: new models.BasicFilter({ table: "a", column: "b" }, "In", ["x", "y"]),
-        nonFilter: <models.IFilter>{}
-      };
-
-      // Act
-
-      // Assert
-      expect(models.isBasicFilter(testData.filter.toJSON())).toBe(true);
-      expect(models.isBasicFilter(testData.nonFilter)).toBe(false);
-    });
-
-    it('isAdvancedFilter should return true for objects with matching shemaUrl and false otherwise', function () {
-      // Arrange
-      const testData = {
-      	filter: new models.AdvancedFilter({ table: "a", column: "b" }, "And", 
+      	basicFilter: new models.BasicFilter({ table: "a", column: "b" }, "In", ["x", "y"]),
+        advancedFilter: new models.AdvancedFilter({ table: "a", column: "b" }, "And", 
           { operator: "Contains", value: "x" },
           { operator: "Contains", value: "x" }
         ),
@@ -476,8 +463,9 @@ describe("Unit | Filters", function () {
       // Act
 
       // Assert
-      expect(models.isAdvancedFilter(testData.filter.toJSON())).toBe(true);
-      expect(models.isAdvancedFilter(testData.nonFilter)).toBe(false);
+      expect(models.getFilterType(testData.basicFilter.toJSON())).toBe(models.FilterType.Basic);
+      expect(models.getFilterType(testData.advancedFilter.toJSON())).toBe(models.FilterType.Advanced);
+      expect(models.getFilterType(testData.nonFilter)).toBe(models.FilterType.Unknown);
     });
   });
 });


### PR DESCRIPTION
The helper functions were only needed to know the type of the filter and we would have to add a function for each type.

The helper functions also don't imply mutually exclusive types since both functions could return true, while the getFilterType does since it can only return one value. This is safer and more scalable.

This also adds new FilterType enum