### PR TITLE
Add IFiltersContainer interface, filtersContainer.json schema, validateFiltersContainer method, and tests for validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,19 @@
 language: node_js
 node_js:
-    - node
+- node
 install:
-    - npm install -g typings typescript
-    - npm link typescript
-    - typings install
-    - npm install
+- npm install -g typings typescript
+- npm link typescript
+- typings install
+- npm install
 script:
-    - gulp test
+- gulp test
+deploy:
+  provider: npm
+  email: nugetpowerbi@microsoft.com
+  api_key:
+    secure: Ly278uVy374sGmTSthu1W37D2314OF2F5hufF8eF3+JaZzFakbM+ld1mn0HOJh7jju3hHMwMLaQEtf2DDrXYsC5kDi37nVnisTPA7G9sWjdT2crW6iZHlnvqjK8I3/cU94NKNb7U3qIZjGL7xT/oyCoKTlHXp0C8VEo8PnnsnhoAIYfJYvyNUk3Vyh9OgyB+C21Ab3HYiK+9dWsFwD7lV96xIvOy8hH+d6OJjSyIYoUJckkI/sKfcJtiFi5e0TMw15tYlwgnRqe1DcREChudgi7bQ/1sqesZwtAT+2X3DiwA08Zmmnoz9txuJcJCRJLYFB3Ki09uOWKlcmIW/LauGeyReabfJXJBXynysJ4dLJfD89/t68LxW1mX0q2kPRs3COmY1IEds7gYJqfLqruyUVhIV7zTwqG5F3S56roLc7OJnA8XXmuQHWRcuNOGvf5PQZHdnVQWNilV1GaNytm19lpvnPX7E14zg2t1PCVtnkj/O/yFSStCOVsX0kI84A7R/hGLzx30nTqVUDe1K81v55mPlJAqc8ChdzZPzosQMIMJYT0bj0dSpHlbZZkZL2JlFdrfy4xH7YVkCPLxwT74lnFaQq6tc7XPfbAz7Ox5RXJ9qaOkyB8pujALbsbvyd0yCZxzFk0cP41vaSRjfGhoQq7M4IMeiv7EAQ8U9CcwwmY=
+  on:
+    tags: true
+    repo: Microsoft/powerbi-models
+    branch: dev

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-models",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Contains JavaScript &amp; TypeScript object models for Microsoft Power BI JavaScript SDK. For each model there is a TypeScript interface, a json schema definitions, and a validation function to ensure and object is valid.",
   "main": "dist/models.js",
   "typings": "dist/models.d.ts",

--- a/src/models.ts
+++ b/src/models.ts
@@ -104,6 +104,10 @@ export interface IPage {
   displayName: string;
 }
 
+export interface IVisual {
+  id: string;
+}
+
 export const validatePage = validate(pageSchema);
 
 export const validateFilter = validate(filterSchema, {

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,6 +2,7 @@ declare var require: Function;
 
 export const advancedFilterSchema = require('./schemas/advancedFilter.json');
 export const filterSchema = require('./schemas/filter.json');
+export const filtersContainerSchema = require('./schemas/filtersContainer.json');
 export const loadSchema = require('./schemas/load.json');
 export const pageSchema = require('./schemas/page.json');
 export const pageTargetSchema = require('./schemas/pageTarget.json');
@@ -110,6 +111,17 @@ export interface IVisual {
 
 export const validatePage = validate(pageSchema);
 
+export const validateFiltersContainer = validate(filtersContainerSchema, {
+  schemas: {
+    target: targetSchema,
+    pageTarget: pageTargetSchema,
+    visualTarget: visualTargetSchema,
+    filter: filterSchema,
+    basicFilter: basicFilterSchema,
+    advancedFilter: advancedFilterSchema
+  }
+})
+
 export const validateFilter = validate(filterSchema, {
   schemas: {
     basicFilter: basicFilterSchema,
@@ -138,6 +150,11 @@ export interface IFilterMeasureTarget extends IBaseFilterTarget {
 }
 
 export declare type IFilterTarget = (IFilterColumnTarget | IFilterHierarchyTarget | IFilterMeasureTarget);
+
+export interface IFiltersContainer {
+  target: ITarget,
+  filters: (IBasicFilter | IAdvancedFilter)[]
+}
 
 export interface IFilter {
   $schema: string;

--- a/src/models.ts
+++ b/src/models.ts
@@ -152,7 +152,7 @@ export interface IFilterMeasureTarget extends IBaseFilterTarget {
 export declare type IFilterTarget = (IFilterColumnTarget | IFilterHierarchyTarget | IFilterMeasureTarget);
 
 export interface IFiltersContainer {
-  target: ITarget,
+  target?: ITarget,
   filters: (IBasicFilter | IAdvancedFilter)[]
 }
 

--- a/src/schemas/filtersContainer.json
+++ b/src/schemas/filtersContainer.json
@@ -13,7 +13,6 @@
     }
   },
   "required": [
-    "target",
     "filters"
   ]
 }

--- a/src/schemas/filtersContainer.json
+++ b/src/schemas/filtersContainer.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "target": {
+      "$ref": "#target"
+    },
+    "filters": {
+      "type": "array",
+      "items": {
+        "$ref": "#filter"
+      }
+    }
+  },
+  "required": [
+    "target",
+    "filters"
+  ]
+}

--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -593,11 +593,20 @@ describe("Unit | Filters", function () {
         ]
       };
 
+      const wellformedFiltersContainerWithoutTarget: models.IFiltersContainer = {
+        filters: [
+          basicFilter,
+          advancedFilter
+        ]
+      };
+
       // Act
       const errors = models.validateFiltersContainer(wellformedFiltersContainer);
+      const errorsNoTarget = models.validateFiltersContainer(wellformedFiltersContainerWithoutTarget);
 
       // Assert
       expect(errors).toBeUndefined();
+      expect(errorsNoTarget).toBeUndefined();
     });
   });
 

--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -3,13 +3,13 @@ import * as models from '../src/models';
 describe('Unit | Models', function () {
   function testForExpectedMessage(errors: models.IError[], message: string) {
     expect(errors).toBeDefined();
-      errors
-        .forEach(error => {
-          if (error.message === message) {
-            expect(true).toBe(true);
-          }
-        });
-  } 
+    errors
+      .forEach(error => {
+        if (error.message === message) {
+          expect(true).toBe(true);
+        }
+      });
+  }
 
   describe('validateLoad', function () {
     const accessTokenRequiredMessage = models.loadSchema.properties.accessToken.messages.required;
@@ -181,25 +181,25 @@ describe("Unit | Filters", function () {
   describe("BasicFilter", function () {
     it("should accept values as separate arguments", function () {
       // Arrange
-      
+
       // Act
       const basicFilter = new models.BasicFilter({ table: "t", column: "c" }, "In", 1, 2);
-      
+
       // Assert
-      expect(basicFilter.values).toEqual([1,2]);
+      expect(basicFilter.values).toEqual([1, 2]);
     });
-    
+
     it("should accept values as an array", function () {
       // Arrange
-      const values = [1,2];
-      
+      const values = [1, 2];
+
       // Act
       const basicFilter = new models.BasicFilter({ table: "t", column: "c" }, "In", values);
-      
+
       // Assert
       expect(basicFilter.values).toEqual(values);
     });
-    
+
     it("should return valid json format when toJSON is called", function () {
       // Arrange
       const expectedFilter: models.IBasicFilter = {
@@ -215,17 +215,17 @@ describe("Unit | Filters", function () {
           3
         ]
       };
-      
+
       // Act
       const filter = new models.BasicFilter(
         expectedFilter.target,
         expectedFilter.operator,
         expectedFilter.values);
-      
+
       // Assert
       expect(filter.toJSON()).toEqual(expectedFilter);
     });
-    
+
     it("validator should return false if object does not validate against schema", function () {
       // Arrange
       const malformedFilter: any = {
@@ -234,14 +234,14 @@ describe("Unit | Filters", function () {
           column: "d"
         }
       };
-      
+
       // Act
       const errors = models.validateFilter(malformedFilter);
-      
+
       // Assert
       expect(errors).toBeDefined();
     });
-    
+
     it("should be able to be validated using json schema", function () {
       // Arrange
       const expectedFilter: models.IBasicFilter = {
@@ -257,13 +257,13 @@ describe("Unit | Filters", function () {
           false
         ]
       };
-      
+
       // Act
       const filter = new models.BasicFilter(
         expectedFilter.target,
         expectedFilter.operator,
         expectedFilter.values);
-      
+
       // Assert
       expect(models.validateFilter(filter.toJSON())).toBeUndefined();
     });
@@ -292,7 +292,7 @@ describe("Unit | Filters", function () {
       expect(filter1.toJSON()).toEqual(filter2.toJSON());
     });
   });
-  
+
   describe("AdvancedFilter", function () {
     it("should throw an error if logical operator is not a non-empty string", function () {
       // Arrange
@@ -300,16 +300,16 @@ describe("Unit | Filters", function () {
         value: "a",
         operator: "LessThan"
       };
-      
+
       // Act
       const attemptToCreateFilter = () => {
         return new models.AdvancedFilter({ table: "t", column: "c" }, <any>1, condition);
       };
-      
+
       // Assert
       expect(attemptToCreateFilter).toThrowError();
     });
-    
+
     it("should throw an error if more than two conditions are provided", function () {
       // Arrange
       const conditions: models.IAdvancedFilterCondition[] = [
@@ -326,17 +326,17 @@ describe("Unit | Filters", function () {
           operator: "LessThan"
         }
       ];
-      
-      
+
+
       // Act
       const attemptToCreateFilter = () => {
         return new models.AdvancedFilter({ table: "Table", column: "c" }, "And", ...conditions);
       };
-      
+
       // Assert
       expect(attemptToCreateFilter).toThrowError();
     });
-    
+
     it("should output the correct json when toJSON is called", function () {
       // Arrange
       const expectedFilter: models.IAdvancedFilter = {
@@ -357,17 +357,17 @@ describe("Unit | Filters", function () {
           }
         ]
       };
-      
+
       // Act
       const filter = new models.AdvancedFilter(
         expectedFilter.target,
         expectedFilter.logicalOperator,
         ...expectedFilter.conditions);
-      
+
       // Assert
       expect(filter.toJSON()).toEqual(expectedFilter);
     });
-    
+
     it("validator should return false if object does not validate against schema", function () {
       // Arrange
       const malformedFilter: any = {
@@ -389,16 +389,16 @@ describe("Unit | Filters", function () {
           }
         ]
       };
-      
+
       // Act
       const errors = models.validateFilter(malformedFilter);
       const errors2 = models.validateFilter(malformedFilter2);
-      
+
       // Assert
       expect(errors).toBeDefined();
       expect(errors2).toBeDefined();
     });
-    
+
     it("should be able to be validated using json schema", function () {
       // Arrange
       const expectedFilter: models.IAdvancedFilter = {
@@ -423,16 +423,16 @@ describe("Unit | Filters", function () {
           }
         ]
       };
-      
+
       const filter = new models.AdvancedFilter(
         expectedFilter.target,
         expectedFilter.logicalOperator,
-        ...expectedFilter.conditions.slice(0,2));
+        ...expectedFilter.conditions.slice(0, 2));
 
       const filter2 = new models.AdvancedFilter(
         expectedFilter.target,
         expectedFilter.logicalOperator,
-        ...expectedFilter.conditions.slice(1,3));
+        ...expectedFilter.conditions.slice(1, 3));
 
       // Act
       const errors = models.validateFilter(filter.toJSON());
@@ -479,10 +479,10 @@ describe("Unit | Filters", function () {
       const malformedPageTarget = {
         type: 'page',
       };
-      
+
       // Act
       const errors = models.validateTarget(malformedPageTarget);
-      
+
       // Assert
       expect(errors).toBeDefined();
     });
@@ -492,10 +492,10 @@ describe("Unit | Filters", function () {
       const malformedVisualTarget = {
         type: 'visual',
       };
-      
+
       // Act
       const errors = models.validateTarget(malformedVisualTarget);
-      
+
       // Assert
       expect(errors).toBeDefined();
     });
@@ -529,12 +529,84 @@ describe("Unit | Filters", function () {
     });
   });
 
+  describe('validateFiltersContainer', function () {
+    it("validator should return errors if object does NOT validate against filtersContainer schema", function () {
+      // Arrange
+      const malformedFiltersContainer = {
+        abc: '123'
+      };
+
+      // Act
+      const errors = models.validateFiltersContainer(malformedFiltersContainer);
+
+      // Assert
+      expect(errors).toBeDefined();
+    });
+
+    it("validator should return no errors if object does validate against filtersContainer schema", function () {
+      // Arrange
+      const things: (string | number)[] = [
+        "a",
+        3234
+      ];
+
+      const basicFilter: models.IBasicFilter = {
+        $schema: "a",
+        target: {
+          table: "table",
+          column: "column"
+        },
+        operator: "In",
+        values: [
+          "A",
+          "B"
+        ]
+      };
+      const advancedFilter: models.IAdvancedFilter = {
+        $schema: "a",
+        target: {
+          table: "table",
+          hierarchy: "hierachy",
+          hierarchyLevel: "hierachyLevel"
+        },
+        logicalOperator: "Or",
+        conditions: [
+          {
+            value: "a",
+            operator: "Contains"
+          },
+          {
+            value: "b",
+            operator: "Contains"
+          }
+        ]
+      };
+
+      const wellformedFiltersContainer: models.IFiltersContainer = {
+        target: {
+          type: "page",
+          name: ""
+        },
+        filters: [
+          basicFilter,
+          advancedFilter
+        ]
+      };
+
+      // Act
+      const errors = models.validateFiltersContainer(wellformedFiltersContainer);
+
+      // Assert
+      expect(errors).toBeUndefined();
+    });
+  });
+
   describe('determine filter type', function () {
     it('getFilterType should return type of filter given a filter object', function () {
       // Arrange
       const testData = {
-      	basicFilter: new models.BasicFilter({ table: "a", column: "b" }, "In", ["x", "y"]),
-        advancedFilter: new models.AdvancedFilter({ table: "a", column: "b" }, "And", 
+        basicFilter: new models.BasicFilter({ table: "a", column: "b" }, "In", ["x", "y"]),
+        advancedFilter: new models.AdvancedFilter({ table: "a", column: "b" }, "And",
           { operator: "Contains", value: "x" },
           { operator: "Contains", value: "x" }
         ),


### PR DESCRIPTION
Add IFiltersContainer interface, filtersContainer.json schema, validateFiltersContainer method, and tests for validation

This allows support for the upcoming `setFilters(filtersContainers: models.IFiltersContainer[])` method which enables developers to set one or more filters at one or more levels with one method call.