### PR TITLE
Add interfaces to support building object representing selection which can include dataPoints and/or regions.

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -321,7 +321,7 @@ export interface IValueDataReference extends IDataReference {
   value: string | boolean | number;
 }
 
-export interface IIdentityValue<T> {
+export interface IIdentityValue<T extends IDataReference> {
   identity: T[];
   values: IValueDataReference[];
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -332,5 +332,5 @@ export interface ISelection {
   report: IReport;
   dataPoints: IIdentityValue<IEqualsDataReference>[];
   regions: IIdentityValue<IEqualsDataReference | IBetweenDataReference>[];
-  filters: (IBasicFilter | IAdvancedFilter)[]
+  filters: (IBasicFilter | IAdvancedFilter)[];
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -78,6 +78,11 @@ export const validateLoad = validate(loadSchema, {
   }
 });
 
+export interface IReport {
+  id: string;
+  displayName: string;
+}
+
 export interface IPage {
   name: string;
   displayName: string;
@@ -85,6 +90,8 @@ export interface IPage {
 
 export interface IVisual {
   name: string;
+  title: string;
+  type: string;
 }
 
 export const validatePage = validate(pageSchema);
@@ -296,4 +303,34 @@ export class AdvancedFilter extends Filter {
 
     return filter;
   }
+}
+
+export interface IDataReference {
+  target: IFilterTarget;
+}
+
+export interface IEqualsDataReference extends IDataReference {
+  equals: string | boolean | number;
+}
+
+export interface IBetweenDataReference extends IDataReference {
+  between: (string | boolean | number)[];
+}
+
+export interface IValueDataReference extends IDataReference {
+  value: string | boolean | number;
+}
+
+export interface IIdentityValue<T> {
+  identity: T[];
+  values: IValueDataReference[];
+}
+
+export interface ISelection {
+  visual: IVisual;
+  page: IPage;
+  report: IReport;
+  dataPoints: IIdentityValue<IEqualsDataReference>[];
+  regions: IIdentityValue<IEqualsDataReference | IBetweenDataReference>[];
+  filters: (IBasicFilter | IAdvancedFilter)[]
 }


### PR DESCRIPTION
Added interfaces based on latest specs from OneNote and email conversations.

This assumes there will be single event raised for both data and region selection and also supports the case where dataPoints and regions are defined in the same event.

@pkwiecien Mentioned including helper classes similar to the `BasicFilter` and `AdvancedFilter` but I did not include any constructor classes yet as I'm not sure how they would offer any help to the developer over simply creating an object using the interface.  The basic and advanced filter helpers were needed because they automatically included the schema url and outputted formatted JSON.  However, these objects don't have any implicit transformations I can see.



