### PR TITLE
fix test: message returned is AccessToken is required.

### DIFF
--- a/test/models.spec.ts
+++ b/test/models.spec.ts
@@ -243,6 +243,7 @@ describe('Unit | Models', function () {
       // Arrange
       const testData = {
         load: {
+          accessToken: 'fakeAccessToken',
           id: 1
         }
       };


### PR DESCRIPTION
test failing: "should return errors with one containing message 'id must be a string' if id is not a string"
message returned is AccessToken is required.
to check the type of id, accessToken should be available. not all errors returned, only the first error.